### PR TITLE
Implement stored photo gallery

### DIFF
--- a/AICameraApp/ContentView.swift
+++ b/AICameraApp/ContentView.swift
@@ -3,6 +3,7 @@ import PhotosUI
 
 struct ContentView: View {
     @State private var showCamera = false
+    @State private var showGallery = false
     @State private var originalImage: UIImage?
     @State private var restoredImage: UIImage?
     private let restorationModel = PhotoRestorationModel()
@@ -36,16 +37,27 @@ struct ContentView: View {
                     if originalImage != nil {
                         Button("Restore Photo") {
                             if let original = originalImage {
-                                restoredImage = restorationModel.restore(image: original)
+                                if let result = restorationModel.restore(image: original) {
+                                    restoredImage = result
+                                    PhotoStorage.shared.save(image: result)
+                                }
                             }
                         }
                         .padding()
                     }
                 }
+
+                Button("View Gallery") {
+                    showGallery.toggle()
+                }
+                .padding(.top)
             }
             .navigationTitle("AI Photo Restorer")
             .sheet(isPresented: $showCamera) {
                 ImagePicker(image: $originalImage)
+            }
+            .sheet(isPresented: $showGallery) {
+                GalleryView()
             }
         }
     }

--- a/AICameraApp/GalleryView.swift
+++ b/AICameraApp/GalleryView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+struct GalleryView: View {
+    @ObservedObject var storage = PhotoStorage.shared
+    @Environment(\.dismiss) private var dismiss
+
+    private let columns = [GridItem(.adaptive(minimum: 100))]
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 16) {
+                    ForEach(storage.photos) { photo in
+                        if let image = UIImage(contentsOfFile: photo.url.path) {
+                            Image(uiImage: image)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 100, height: 100)
+                                .clipped()
+                                .contextMenu {
+                                    Button("Delete", role: .destructive) {
+                                        storage.delete(photo)
+                                    }
+                                }
+                        }
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Gallery")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Done") { dismiss() }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if !storage.photos.isEmpty {
+                        Button("Clear", role: .destructive) {
+                            storage.clear()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct GalleryView_Previews: PreviewProvider {
+    static var previews: some View {
+        GalleryView()
+    }
+}

--- a/AICameraApp/PhotoStorage.swift
+++ b/AICameraApp/PhotoStorage.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+class PhotoStorage: ObservableObject {
+    static let shared = PhotoStorage()
+    
+    @Published private(set) var photos: [RestoredPhoto] = []
+    private let directory: URL
+    
+    private init() {
+        let fm = FileManager.default
+        directory = fm.urls(for: .documentDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("RestoredPhotos")
+        try? fm.createDirectory(at: directory, withIntermediateDirectories: true)
+        loadPhotos()
+    }
+    
+    func save(image: UIImage) {
+        let id = UUID()
+        let url = directory.appendingPathComponent("\(id.uuidString).jpg")
+        guard let data = image.jpegData(compressionQuality: 0.9) else { return }
+        do {
+            try data.write(to: url)
+            let photo = RestoredPhoto(id: id, url: url)
+            photos.append(photo)
+        } catch {
+            print("Failed to save image: \(error)")
+        }
+    }
+    
+    func delete(_ photo: RestoredPhoto) {
+        do {
+            try FileManager.default.removeItem(at: photo.url)
+        } catch {
+            print("Failed to delete image: \(error)")
+        }
+        photos.removeAll { $0.id == photo.id }
+    }
+    
+    func clear() {
+        for photo in photos {
+            try? FileManager.default.removeItem(at: photo.url)
+        }
+        photos.removeAll()
+    }
+    
+    private func loadPhotos() {
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil) else { return }
+        photos = files.compactMap { url in
+            let idString = url.deletingPathExtension().lastPathComponent
+            return RestoredPhoto(id: UUID(uuidString: idString) ?? UUID(), url: url)
+        }.sorted { $0.id.uuidString < $1.id.uuidString }
+    }
+}

--- a/AICameraApp/RestoredPhoto.swift
+++ b/AICameraApp/RestoredPhoto.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct RestoredPhoto: Identifiable {
+    let id: UUID
+    let url: URL
+    
+    init(id: UUID = UUID(), url: URL) {
+        self.id = id
+        self.url = url
+    }
+}


### PR DESCRIPTION
## Summary
- add `RestoredPhoto` model and persistent `PhotoStorage`
- implement `GalleryView` UI with delete/clear controls
- extend `ContentView` to save restorations and show the gallery

## Testing
- `swiftc -typecheck AICameraApp/*.swift`


------
https://chatgpt.com/codex/tasks/task_e_684b85f2504883318403b41b362161a6