### PR TITLE
Enable photo library selection

### DIFF
--- a/AICameraApp/ContentView.swift
+++ b/AICameraApp/ContentView.swift
@@ -2,7 +2,8 @@ import SwiftUI
 import PhotosUI
 
 struct ContentView: View {
-    @State private var showCamera = false
+    @State private var showImagePicker = false
+    @State private var pickerSource: UIImagePickerController.SourceType = .camera
     @State private var originalImage: UIImage?
     @State private var restoredImage: UIImage?
     private let restorationModel = PhotoRestorationModel()
@@ -29,7 +30,14 @@ struct ContentView: View {
 
                 HStack {
                     Button("Take Photo") {
-                        showCamera.toggle()
+                        pickerSource = .camera
+                        showImagePicker.toggle()
+                    }
+                    .padding()
+
+                    Button("Choose Photo") {
+                        pickerSource = .photoLibrary
+                        showImagePicker.toggle()
                     }
                     .padding()
 
@@ -44,8 +52,8 @@ struct ContentView: View {
                 }
             }
             .navigationTitle("AI Photo Restorer")
-            .sheet(isPresented: $showCamera) {
-                ImagePicker(image: $originalImage)
+            .sheet(isPresented: $showImagePicker) {
+                ImagePicker(image: $originalImage, sourceType: pickerSource)
             }
         }
     }

--- a/AICameraApp/ImagePicker.swift
+++ b/AICameraApp/ImagePicker.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct ImagePicker: UIViewControllerRepresentable {
     @Binding var image: UIImage?

--- a/AICameraApp/Info.plist
+++ b/AICameraApp/Info.plist
@@ -14,5 +14,7 @@
     <string>LaunchScreen</string>
     <key>NSCameraUsageDescription</key>
     <string>We need access to the camera to capture photos.</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>We need access to your photo library to select photos.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- support importing photos with ImagePicker
- add a button to choose existing photos
- request permission to access the photo library

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_684b85e9b2848331954e5105eb71361b