### PR TITLE
Improve photo picker resilience

### DIFF
--- a/AICameraApp/ContentView.swift
+++ b/AICameraApp/ContentView.swift
@@ -6,6 +6,7 @@ struct ContentView: View {
     @State private var pickerSource: UIImagePickerController.SourceType = .camera
     @State private var originalImage: UIImage?
     @State private var restoredImage: UIImage?
+    private let cameraAvailable = UIImagePickerController.isSourceTypeAvailable(.camera)
     private let restorationModel = PhotoRestorationModel()
 
     var body: some View {
@@ -34,6 +35,7 @@ struct ContentView: View {
                         showImagePicker.toggle()
                     }
                     .padding()
+                    .disabled(!cameraAvailable)
 
                     Button("Choose Photo") {
                         pickerSource = .photoLibrary
@@ -54,6 +56,9 @@ struct ContentView: View {
             .navigationTitle("AI Photo Restorer")
             .sheet(isPresented: $showImagePicker) {
                 ImagePicker(image: $originalImage, sourceType: pickerSource)
+            }
+            .onChange(of: originalImage) { _ in
+                restoredImage = nil
             }
         }
     }

--- a/AICameraApp/ImagePicker.swift
+++ b/AICameraApp/ImagePicker.swift
@@ -11,7 +11,11 @@ struct ImagePicker: UIViewControllerRepresentable {
 
     func makeUIViewController(context: Context) -> UIImagePickerController {
         let picker = UIImagePickerController()
-        picker.sourceType = sourceType
+        if UIImagePickerController.isSourceTypeAvailable(sourceType) {
+            picker.sourceType = sourceType
+        } else {
+            picker.sourceType = .photoLibrary
+        }
         picker.delegate = context.coordinator
         return picker
     }

--- a/AICameraApp/PhotoRestorationModel.swift
+++ b/AICameraApp/PhotoRestorationModel.swift
@@ -17,6 +17,7 @@ class PhotoRestorationModel {
         guard let model = model else { return nil }
         guard let cgImage = image.cgImage else { return nil }
         let request = VNCoreMLRequest(model: model)
+        request.imageCropAndScaleOption = .scaleFit
         let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
         try? handler.perform([request])
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ An iOS app that lets you capture old family photos and restore them on device us
 
 ## Features
 - Capture photos using the device camera.
+- Select existing photos from the photo library.
 - Run a photo restoration model on the captured image.
 - Display the restored image alongside the original.
 
@@ -13,8 +14,9 @@ An iOS app that lets you capture old family photos and restore them on device us
 - A device capable of running Core ML models (e.g. iPhone with A12 Bionic or newer).
 
 ## Building
-1. Open `AICameraApp.xcodeproj` or create a new SwiftUI iOS project in Xcode and add the files inside the `AICameraApp` directory.
+1. Create a new SwiftUI iOS project in Xcode and add the files inside the `AICameraApp` directory.
 2. Add a compiled Core ML model named `PhotoRestoration.mlmodel` to the project. Xcode will produce a `.mlmodelc` compiled model that the app expects.
-3. Build and run on a physical device.
+3. Ensure the `Info.plist` contains camera and photo library usage descriptions.
+4. Build and run on a physical device.
 
 The sample `PhotoRestorationModel` class expects the model to take an image input and produce an image output. You can replace it with any Core ML model that performs image restoration.


### PR DESCRIPTION
## Summary
- document building with a new Xcode project only
- disable "Take Photo" button if the camera isn't available
- clear restored image when a new photo is picked
- fall back to the photo library if camera source isn't available
- ensure Core ML request scales input properly

## Testing
- `swiftc -parse AICameraApp/ContentView.swift`
- `swiftc -parse AICameraApp/ImagePicker.swift`
- `swiftc -parse AICameraApp/PhotoRestorationModel.swift`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b9a224d68833186b00e859800fb60